### PR TITLE
fix: increase the timeout for message exporter API

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,9 @@ import {
 
 const apiKey = need<string>(process.env.COPILOT_API_KEY);
 
+// One minute
+export const maxDuration = 60000;
+
 export default async function Home({
   searchParams,
 }: {


### PR DESCRIPTION
Increase the timeout to one minute (instead of the 15s default) for message exporter server actions.